### PR TITLE
Updating Dockerfile and requirements to build discordpy from master branch containing fix for voice error 4006

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
     musl-dev \
     libffi-dev \
     gcc \
+    git \
     && pip install --upgrade pip  # Make sure pip is up to date
 
 # Set the working directory in the container

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies for Discord bot
 discord.py
-discord.py[voice]
+git+https://github.com/Rapptz/discord.py@master#egg=discord.py[voice]
 discord.py-pagination
 
 # Utility and external libraries


### PR DESCRIPTION
**Summary**
- Updates the DiscordPy installation to use the master branch

**Reason**
- At time of writing, a PR for DiscordPy was made to address a 4006 error code when the bot tries to join the voice channel.
- Without this, the bot frequently has issues joining the voice channel and playing music (at least on U.S. Discord servers)
- Since the code is merged on their master branch but not yet in a release, this expedites the fix